### PR TITLE
Added $strict option and FilenameRev::existsInManifest()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 
@@ -11,9 +10,9 @@ env:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.0
       env: setup=lowest
-    - php: 5.6
+    - php: 7.1
       env: setup=stable
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Once activated and configured you can use the `rev()` function in your templates
 <link rel="stylesheet" href="{{ rev('css/main.css') }}">
 ```
 
-In some cases (e.g. when building additional files that aren't available in the manifest file), you can prevent the extension from throwing an exception about a missing file mapping by setting the optional `$strict` parameter to `false`: 
+In some cases (e.g. when building additional files that aren't available in the manifest file or are files that are served via proxy), you can prevent the extension from throwing an exception about a missing file mapping by setting the optional `$strict` parameter to `false`: 
 
 ```
 <link rel="stylesheet" href="{{ rev('css/not-available-in-manifest.css', false) }}">

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Once activated and configured you can use the `rev()` function in your templates
 <link rel="stylesheet" href="{{ rev('css/main.css') }}">
 ```
 
+In some cases (e.g. when building additional files that aren't available in the manifest file), you can prevent the extension from throwing an exception about a missing file mapping by setting the optional `$strict` parameter to `false`: 
+
+```
+<link rel="stylesheet" href="{{ rev('css/not-available-in-manifest.css', false) }}">
+```
+
+This will append a query string (see below) if the file does not exist in the manifest file: `css/not-available-in-manifest.css?1473534554`.
+
 ### Manifest Files
 
 `css/main.css` will be replaced with the corresponding hashed filename as defined within your assets manifest .json file.

--- a/src/AssetRevTwigExtension.php
+++ b/src/AssetRevTwigExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Club\AssetRev;
 
 use Twig_Extension;

--- a/src/AssetRevTwigExtension.php
+++ b/src/AssetRevTwigExtension.php
@@ -31,11 +31,13 @@ class AssetRevTwigExtension extends Twig_Extension
     /**
      * Get the filename of a asset
      *
-     * @param $file
+     * @param      $file
+     * @param bool $strict      Throw an exception if the file does not exist in the manifest file.
+     *
      * @return string
      */
-    public function getAssetFilename($file)
+    public function getAssetFilename($file, $strict = true)
     {
-        return AssetRev::getInstance()->assetRev->getAssetFilename($file);
+        return AssetRev::getInstance()->assetRev->getAssetFilename($file, $strict);
     }
 }

--- a/src/AssetRevTwigExtension.php
+++ b/src/AssetRevTwigExtension.php
@@ -17,7 +17,7 @@ class AssetRevTwigExtension extends Twig_Extension
     }
 
     /**
-     * Get Twig Functions
+     * Get Twig Functions.
      *
      * @return array
      */
@@ -29,7 +29,7 @@ class AssetRevTwigExtension extends Twig_Extension
     }
 
     /**
-     * Get the filename of a asset
+     * Get the filename of a asset.
      *
      * @param      $file
      * @param bool $strict      Throw an exception if the file does not exist in the manifest file.

--- a/src/services/AssetRev.php
+++ b/src/services/AssetRev.php
@@ -11,9 +11,10 @@ class AssetRev extends \craft\base\Component
      * Get the filename of a asset
      *
      * @param $file
+     * @param $strict bool
      * @return string
      */
-    public function getAssetFilename($file)
+    public function getAssetFilename($file, $strict)
     {
         $revver = new FilenameRev(
             \Club\AssetRev\AssetRev::getInstance()->settings->manifestPath,
@@ -23,6 +24,6 @@ class AssetRev extends \craft\base\Component
 
         $revver->setBasePath(CRAFT_BASE_PATH . DIRECTORY_SEPARATOR);
 
-        return $revver->rev($file);
+        return $revver->rev($file, $strict);
     }
 }

--- a/src/services/AssetRev.php
+++ b/src/services/AssetRev.php
@@ -1,14 +1,12 @@
 <?php
 namespace Club\AssetRev\services;
 
-use Craft;
-use InvalidArgumentException;
 use Club\AssetRev\utilities\FilenameRev;
 
 class AssetRev extends \craft\base\Component
 {
     /**
-     * Get the filename of a asset
+     * Get the filename of a asset.
      *
      * @param $file
      * @param $strict bool

--- a/src/services/AssetRev.php
+++ b/src/services/AssetRev.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Club\AssetRev\services;
 
 use Club\AssetRev\utilities\FilenameRev;

--- a/src/utilities/FilenameRev.php
+++ b/src/utilities/FilenameRev.php
@@ -42,12 +42,15 @@ class FilenameRev
     public function rev($file, $strict)
     {
         $manifest = $this->getAbsolutePath($this->manifestPath);
+        $revvedFile = null;
 
-        $revvedFile = $this->manifestExists($manifest) && ($strict || $this->existsInManifest($manifest, $file)) ?
-            $this->revUsingManifest($manifest, $file) :
-            $this->appendQueryString($file);
+        if ($this->manifestExists($manifest) && ($strict || $this->existsInManifest($manifest, $file))) {
+            $revvedFile = $this->revUsingManifest($manifest, $file);
+        } elseif ($strict || file_exists($file)) {
+            $revvedFile = $this->appendQueryString($file);
+        }
 
-        return $this->prependAssetPrefix($revvedFile);
+        return $this->prependAssetPrefix($revvedFile ?? $file);
     }
 
     protected function manifestExists($manifestPath)

--- a/src/utilities/FilenameRev.php
+++ b/src/utilities/FilenameRev.php
@@ -39,11 +39,11 @@ class FilenameRev
         return $this->basePath . $file;
     }
 
-    public function rev($file)
+    public function rev($file, $strict)
     {
         $manifest = $this->getAbsolutePath($this->manifestPath);
 
-        $revvedFile = $this->manifestExists($manifest) ?
+        $revvedFile = $this->manifestExists($manifest) && ($strict || $this->existsInManifest($manifest, $file)) ?
             $this->revUsingManifest($manifest, $file) :
             $this->appendQueryString($file);
 
@@ -53,6 +53,15 @@ class FilenameRev
     protected function manifestExists($manifestPath)
     {
         return is_file($manifestPath);
+    }
+
+    protected function existsInManifest($manifest, $file)
+    {
+        if (is_null(self::$manifest)) {
+            self::$manifest = json_decode(file_get_contents($manifest), true);
+        }
+
+        return isset(self::$manifest[$file]);
     }
 
     protected function revUsingManifest($manifest, $file)

--- a/tests/utilities/FilenameRevTest.php
+++ b/tests/utilities/FilenameRevTest.php
@@ -49,7 +49,7 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new FilenameRev)->rev('missing-file.css');
+        (new FilenameRev)->rev('missing-file.css', true);
     }
 
     /**
@@ -66,7 +66,7 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $asset . '?' . filemtime($assetPath),
-            $revver->rev($asset)
+            $revver->rev($asset, true)
         );
     }
 
@@ -84,7 +84,7 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             'asset/base/path/files/asset.css?' . filemtime($assetPath),
-            $revver->rev($asset)
+            $revver->rev($asset, true)
         );
     }
 
@@ -102,7 +102,7 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $assetsPath . $asset . '?' . filemtime($assetPath),
-            $revver->rev($asset)
+            $revver->rev($asset, true)
         );
     }
 
@@ -121,7 +121,7 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
 
         $revver = new FilenameRev('files/manifest.json');
         $revver->setBasePath($assetsPath);
-        $revver->rev($asset);
+        $revver->rev($asset, true);
     }
 
     /**
@@ -137,7 +137,7 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             'css/asset.a9961d38.css',
-            $revver->rev('css/asset.css')
+            $revver->rev('css/asset.css', true)
         );
     }
 
@@ -154,7 +154,7 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             'css/asset.a9961d38.css',
-            $revver->rev('css/asset.css')
+            $revver->rev('css/asset.css', true)
         );
     }
 }

--- a/tests/utilities/FilenameRevTest.php
+++ b/tests/utilities/FilenameRevTest.php
@@ -73,6 +73,24 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_appends_filemtime_as_a_query_string_if_the_file_to_rev_doesnt_exist_in_the_manifest_file()
+    {
+        $asset = 'files/copied-asset.css';
+        $assetPath = stream_resolve_include_path($asset);
+        $assetsPath = str_replace($asset, '', $assetPath);
+
+        $revver = new FilenameRev('files/manifest.json');
+        $revver->setBasePath($assetsPath);
+
+        $this->assertEquals(
+            $asset . '?' . filemtime($assetPath),
+            $revver->rev($asset, false)
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_prepends_the_asset_prefix_to_the_outputted_file_name()
     {
         $asset = 'files/asset.css';

--- a/tests/utilities/FilenameRevTest.php
+++ b/tests/utilities/FilenameRevTest.php
@@ -91,6 +91,22 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_returns_the_assets_path_if_the_file_doesnt_exist_and_strict_is_false()
+    {
+        $asset = 'missing-file.css';
+        $assetPrefix = '/asset/base/path';
+
+        $revver = new FilenameRev(null, null, $assetPrefix);
+
+        $this->assertEquals(
+            $assetPrefix . $asset,
+            $revver->rev($asset, false)
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_prepends_the_asset_prefix_to_the_outputted_file_name()
     {
         $asset = 'files/asset.css';


### PR DESCRIPTION
In our (probably not-so-common) case we also copy a couple of files to the asset output directory that we know will be there but aren't available from the manifest file. This caused an [`InvalidArgumentException` in `FilenameRev`](https://github.com/clubstudioltd/craft3-asset-rev/blob/master/src/utilities/FilenameRev.php#L65), with no option to get around this.

This PR introduces an optional `$strict` parameter to the `{{ rev(...) }}` Twig function that allows you to have `FilenameRev` fallback to appending a query string in case the file does not exist in the manifest. The README has been updated accordingly with an example.